### PR TITLE
A few changes mostly related to translations

### DIFF
--- a/build-aux/io.github.davidoc26.wallpaper_selector.Devel.json
+++ b/build-aux/io.github.davidoc26.wallpaper_selector.Devel.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.davidoc26.wallpaper_selector.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"

--- a/build-aux/io.github.davidoc26.wallpaper_selector.json
+++ b/build-aux/io.github.davidoc26.wallpaper_selector.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.davidoc26.wallpaper_selector",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"

--- a/data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in
+++ b/data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in
@@ -23,27 +23,27 @@
   <content_rating type="oars-1.0" />
   <releases>
     <release version="0.3.2" date="2023-06-03">
-      <description>
+      <description translatable="no">
         <p>Minor improvements and the ability to open the folder with installed wallpapers</p>
       </description>
     </release>
     <release version="0.3.1" date="2022-10-23">
-      <description>
+      <description translatable="no">
         <p>Small correction: window refresh after category selection</p>
       </description>
     </release>
     <release version="0.3.0" date="2022-07-17">
-      <description>
+      <description translatable="no">
         <p>Added preferences window and the ability to choose a wallpaper category</p>
       </description>
     </release>
     <release version="0.2.0" date="2022-06-11">
-      <description>
+      <description translatable="no">
         <p>Removed flatpak d-bus access, uses portals instead</p>
       </description>
     </release>
     <release version="0.1.0" date="2022-06-09">
-      <description>
+      <description translatable="no">
         <p>First release! Supports only gnome now</p>
       </description>
     </release>

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: io.github.davidoc26.wallpaper_selector\n"
 "Report-Msgid-Bugs-To: https://github.com/davidoc26/wallpaper-selector\n"
-"POT-Creation-Date: 2022-10-23 16:53+0300\n"
-"PO-Revision-Date: 2022-10-23 18:11+0300\n"
+"POT-Creation-Date: 2023-10-09 11:18+0300\n"
+"PO-Revision-Date: 2023-10-09 11:27+0300\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Türkçe <gnome-turk@gnome.org>\n"
 "Language: tr\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.4\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: NC_;G_;_;C_;gettext\n"
 "X-Poedit-SearchPath-0: src\n"
@@ -25,6 +25,7 @@ msgstr ""
 
 #: data/io.github.davidoc26.wallpaper_selector.desktop.in.in:3
 #: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:7
+#: src/main.rs:29
 msgid "Wallpaper Selector"
 msgstr "Duvar Kağıdı Seçici"
 
@@ -58,7 +59,9 @@ msgstr "Duvar kağıtlarını indirir ve uygular"
 
 #: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:10
 msgid "Simple application to download and set wallpapers from wallhaven"
-msgstr "Wallhaven sitesinden duvar kağıtları indirmek ve uygulamak için basit bir uygulama"
+msgstr ""
+"Wallhaven sitesinden duvar kağıtları indirmek ve uygulamak için basit bir "
+"uygulama"
 
 #: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:13
 msgid "wallpapers"
@@ -68,41 +71,9 @@ msgstr "wallpapers"
 msgid "Main window"
 msgstr "Ana pencere"
 
-#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:27
-msgid "Small correction: window refresh after category selection"
-msgstr "Küçük düzeltme: kategori seçiminden sonra pencere yenileme"
-
-#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:32
-msgid "Added preferences window and the ability to choose a wallpaper category"
-msgstr "Tercihler penceresi ve duvar kağıdı kategorisi seçme yeteneği eklendi"
-
-#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:37
-msgid "Removed flatpak d-bus access, uses portals instead"
-msgstr "Flatpak d-bus erişimi kaldırıldı, bunun yerine portallar kullanılıyor"
-
-#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:42
-msgid "First release! Supports only gnome now"
-msgstr "İlk sürüm! Şimdilik sadece GNOME'u destekliyor"
-
-#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:50
+#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:55
 msgid "David Eritsyan"
 msgstr "David Eritsyan"
-
-#: data/resources/ui/preferences.ui:9 data/resources/ui/preferences.ui:21
-msgid "General"
-msgstr "Genel"
-
-#: data/resources/ui/preferences.ui:16
-msgid "_Category"
-msgstr "_Kategori"
-
-#: data/resources/ui/preferences.ui:22
-msgid "Anime"
-msgstr "Anime"
-
-#: data/resources/ui/preferences.ui:23
-msgid "People"
-msgstr "Kişiler"
 
 #: data/resources/ui/shortcuts.ui:11
 msgctxt "shortcut window"
@@ -124,21 +95,60 @@ msgid "_Preferences"
 msgstr "_Tercihler"
 
 #: data/resources/ui/window.ui:10
+msgid "Open Wallpapers Folder"
+msgstr "Duvar Kağıtları Klasörünü Aç"
+
+#: data/resources/ui/window.ui:16
 msgid "_Keyboard Shortcuts"
 msgstr "_Klavye Kısayolları"
 
-#: data/resources/ui/window.ui:14
+#: data/resources/ui/window.ui:20
 msgid "_About Wallpaper Selector"
 msgstr "Duvar Kağıdı Seçici _Hakkında"
 
+#: data/resources/ui/preferences.ui:9 data/resources/ui/preferences.ui:21
+msgid "General"
+msgstr "Genel"
+
+#: data/resources/ui/preferences.ui:16
+msgid "_Category"
+msgstr "_Kategori"
+
+#: data/resources/ui/preferences.ui:22
+msgid "Anime"
+msgstr "Anime"
+
+#: data/resources/ui/preferences.ui:23
+msgid "People"
+msgstr "Kişiler"
+
+#: src/application.rs:174
+msgid "translator-credits"
+msgstr "Sabri Ünal <libreajans@gmail.com>"
+
+#: src/window.rs:214
 msgid "Downloading your new wallpaper 🙂"
 msgstr "Yeni duvar kağıdınız indiriliyor 🙂"
 
+#: src/window.rs:234
 msgid "Enjoy 🤘"
 msgstr "Tadını çıkarın 🤘"
 
+#: src/window.rs:242 src/window.rs:249
 msgid "Something went wrong"
 msgstr "Bir şeyler yanlış gitti"
 
-msgid "translator-credits"
-msgstr "Sabri Ünal <libreajans@gmail.com>"
+#~ msgid "Small correction: window refresh after category selection"
+#~ msgstr "Küçük düzeltme: kategori seçiminden sonra pencere yenileme"
+
+#~ msgid ""
+#~ "Added preferences window and the ability to choose a wallpaper category"
+#~ msgstr ""
+#~ "Tercihler penceresi ve duvar kağıdı kategorisi seçme yeteneği eklendi"
+
+#~ msgid "Removed flatpak d-bus access, uses portals instead"
+#~ msgstr ""
+#~ "Flatpak d-bus erişimi kaldırıldı, bunun yerine portallar kullanılıyor"
+
+#~ msgid "First release! Supports only gnome now"
+#~ msgstr "İlk sürüm! Şimdilik sadece GNOME'u destekliyor"

--- a/po/wallpaper_selector.pot
+++ b/po/wallpaper_selector.pot
@@ -1,0 +1,131 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-09 11:18+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/io.github.davidoc26.wallpaper_selector.desktop.in.in:3
+#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:7
+#: src/main.rs:29
+msgid "Wallpaper Selector"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.desktop.in.in:4
+msgid "Simple application to download and set wallpapers"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.desktop.in.in:9
+msgid "Gnome;GTK;"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.gschema.xml.in:6
+msgid "Window width"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.gschema.xml.in:10
+msgid "Window height"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.gschema.xml.in:14
+msgid "Window maximized state"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.gschema.xml.in:18
+msgid "Wallpapers category"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:8
+msgid "Downloads and applies wallpapers"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:10
+msgid "Simple application to download and set wallpapers from wallhaven"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:13
+msgid "wallpapers"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:18
+msgid "Main window"
+msgstr ""
+
+#: data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in:55
+msgid "David Eritsyan"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:11
+msgctxt "shortcut window"
+msgid "General"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:14
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr ""
+
+#: data/resources/ui/shortcuts.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr ""
+
+#: data/resources/ui/window.ui:6
+msgid "_Preferences"
+msgstr ""
+
+#: data/resources/ui/window.ui:10
+msgid "Open Wallpapers Folder"
+msgstr ""
+
+#: data/resources/ui/window.ui:16
+msgid "_Keyboard Shortcuts"
+msgstr ""
+
+#: data/resources/ui/window.ui:20
+msgid "_About Wallpaper Selector"
+msgstr ""
+
+#: data/resources/ui/preferences.ui:9 data/resources/ui/preferences.ui:21
+msgid "General"
+msgstr ""
+
+#: data/resources/ui/preferences.ui:16
+msgid "_Category"
+msgstr ""
+
+#: data/resources/ui/preferences.ui:22
+msgid "Anime"
+msgstr ""
+
+#: data/resources/ui/preferences.ui:23
+msgid "People"
+msgstr ""
+
+#: src/application.rs:174
+msgid "translator-credits"
+msgstr ""
+
+#: src/window.rs:214
+msgid "Downloading your new wallpaper 🙂"
+msgstr ""
+
+#: src/window.rs:234
+msgid "Enjoy 🤘"
+msgstr ""
+
+#: src/window.rs:242 src/window.rs:249
+msgid "Something went wrong"
+msgstr ""


### PR DESCRIPTION
### data: Mark release descriptions as untranslatable

GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way. This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.

### po: Add a POT file

May help translators. Created via the following command:
`xgettext --files-from=po/POTFILES.in --output=po/wallpaper_selector.pot --from-code=UTF-8 --add-comments --keyword=gettext --keyword=_ --keyword=NC_ keyword=G_ --keyword=C_:1c,2

### Update Turkish traslation

### Update runtime version

I did to compile the app with recent version of runtime. It works without error.

