### PR TITLE
Appdata related changes

### DIFF
--- a/data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in
+++ b/data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in
@@ -28,32 +28,32 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="0.3.3" date="2024-01-21">
-      <description translatable="no">
+      <description translate="no">
         <p>Minor improvements and runtime version update</p>
       </description>
     </release>
     <release version="0.3.2" date="2023-06-03">
-      <description translatable="no">
+      <description translate="no">
         <p>Minor improvements and the ability to open the folder with installed wallpapers</p>
       </description>
     </release>
     <release version="0.3.1" date="2022-10-23">
-      <description translatable="no">
+      <description translate="no">
         <p>Small correction: window refresh after category selection</p>
       </description>
     </release>
     <release version="0.3.0" date="2022-07-17">
-      <description translatable="no">
+      <description translate="no">
         <p>Added preferences window and the ability to choose a wallpaper category</p>
       </description>
     </release>
     <release version="0.2.0" date="2022-06-11">
-      <description translatable="no">
+      <description translate="no">
         <p>Removed flatpak d-bus access, uses portals instead</p>
       </description>
     </release>
     <release version="0.1.0" date="2022-06-09">
-      <description translatable="no">
+      <description translate="no">
         <p>First release! Supports only gnome now</p>
       </description>
     </release>

--- a/data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in
+++ b/data/io.github.davidoc26.wallpaper_selector.metainfo.xml.in.in
@@ -63,6 +63,9 @@
      <kudo>HiDpiIcon</kudo>
   </kudos>
   <developer_name>David Eritsyan</developer_name>
+  <developer id="io.github.davidoc26">
+    <name>David Eritsyan</name>
+  </developer>
   <update_contact>dav.eritsyan@gmail.com</update_contact>
   <translation type="gettext">@gettext-package@</translation>
   <launchable type="desktop-id">@app-id@.desktop</launchable>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer