### PR TITLE
fix: crash on changing sorting type with different app locale

### DIFF
--- a/build-aux/io.github.davidoc26.wallpaper_selector.Devel.json
+++ b/build-aux/io.github.davidoc26.wallpaper_selector.Devel.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.davidoc26.wallpaper_selector.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -25,7 +25,7 @@
             "RUST_LOG": "wallpaper_selector=debug"
         }
     },
-    "cleanup" : [
+    "cleanup": [
         "/include",
         "/lib/pkgconfig",
         "/man",

--- a/build-aux/io.github.davidoc26.wallpaper_selector.json
+++ b/build-aux/io.github.davidoc26.wallpaper_selector.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.davidoc26.wallpaper_selector",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -20,7 +20,7 @@
             "--share=network"
         ]
     },
-    "cleanup" : [
+    "cleanup": [
         "/include",
         "/lib/pkgconfig",
         "/man",

--- a/src/api/wallhaven.rs
+++ b/src/api/wallhaven.rs
@@ -1,5 +1,5 @@
 pub mod client {
-    use std::error::Error;
+    use std::{error::Error, fmt::Display};
 
     use bytes::Bytes;
 
@@ -107,7 +107,7 @@ pub mod client {
         }
     }
 
-    #[derive(Default)]
+    #[derive(Default, Debug)]
     pub enum Sorting {
         #[default]
         Latest,
@@ -127,6 +127,18 @@ pub mod client {
         }
     }
 
+    impl Display for Sorting {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let value = match self {
+                Sorting::Latest => "Latest",
+                Sorting::Hot => "Hot",
+                Sorting::Toplist => "Toplist",
+                Sorting::Random => "Random",
+            };
+            write!(f, "{}", value)
+        }
+    }
+
     impl From<&str> for Sorting {
         fn from(s: &str) -> Self {
             match s {
@@ -138,6 +150,7 @@ pub mod client {
             }
         }
     }
+
     impl From<Sorting> for u32 {
         fn from(val: Sorting) -> Self {
             match val {
@@ -145,6 +158,18 @@ pub mod client {
                 Sorting::Toplist => 1,
                 Sorting::Hot => 2,
                 Sorting::Random => 3,
+            }
+        }
+    }
+
+    impl From<u32> for Sorting {
+        fn from(value: u32) -> Self {
+            match value {
+                0 => Sorting::Latest,
+                1 => Sorting::Toplist,
+                2 => Sorting::Hot,
+                3 => Sorting::Random,
+                _ => Sorting::Latest,
             }
         }
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -434,15 +434,12 @@ impl WallpaperSelectorWindow {
                 #[strong(rename_to = window)]
                 self,
                 move |item| {
-                    let item = item
-                        .selected_item()
-                        .and_downcast::<gtk::StringObject>()
-                        .unwrap();
-
+                    let item = item.selected();
+                    let sorting_type = Sorting::from(item).to_string();
                     window
                         .imp()
                         .settings
-                        .set("wallpapers-sorting", item.string().as_str())
+                        .set("wallpapers-sorting", sorting_type)
                         .unwrap();
                     window.provider().reset();
                     window.clear_model();


### PR DESCRIPTION
This PR fixes a crash that occurs when changing sorting type while using the app in a different language.

Closes #42 